### PR TITLE
feat: initial impl

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -200,6 +200,7 @@ export default function (bucketPrefix, aws) {
   function makeNamespace(name) {
     // will succeed if the bucket already exists
     return client.makeBucket(namespacedBucket)
+      .chain(() => checkName(name))
       .chain(getMeta)
       .chain((meta) =>
         checkNamespaceExists(meta, name)
@@ -290,8 +291,8 @@ export default function (bucketPrefix, aws) {
   async function putObject({ bucket, object, stream }) {
     const arrBuffer = await readAll(stream);
 
-    return Async.of(object)
-      .chain(checkName)
+    return checkName(bucket)
+      .chain(() => checkName(object))
       .chain(getMeta)
       .chain(
         (meta) => checkNamespaceExists(meta, bucket),
@@ -317,8 +318,8 @@ export default function (bucketPrefix, aws) {
    * @returns {Promise<ResponseOk>}
    */
   function removeObject({ bucket, object }) {
-    return Async.of(object)
-      .chain(checkName)
+    return checkName(bucket)
+      .chain(() => checkName(object))
       .chain(getMeta)
       .chain(
         (meta) => checkNamespaceExists(meta, bucket),
@@ -343,8 +344,8 @@ export default function (bucketPrefix, aws) {
    * @returns {Promise<Buffer>}
    */
   function getObject({ bucket, object }) {
-    return Async.of(object)
-      .chain(checkName)
+    return checkName(bucket)
+      .chain(() => checkName(object))
       .chain(getMeta)
       .chain(
         (meta) => checkNamespaceExists(meta, bucket),
@@ -369,8 +370,8 @@ export default function (bucketPrefix, aws) {
    * @returns {Promise<ResponseObjects>}
    */
   function listObjects({ bucket, prefix }) {
-    return Async.of(prefix)
-      .chain(checkName)
+    return checkName(bucket)
+      .chain(() => checkName(prefix))
       .chain(getMeta)
       .chain(
         (meta) => checkNamespaceExists(meta, bucket),

--- a/adapter.js
+++ b/adapter.js
@@ -1,124 +1,405 @@
-// deno-lint-ignore-file no-unused-vars
+import { Buffer, crocks, join, R, readAll } from "./deps.js";
+
+import * as lib from "./lib/s3.js";
+
+import { checkName, mapErr } from "./lib/utils.js";
+
+const { Async } = crocks;
+const {
+  assocPath,
+  assoc,
+  dissoc,
+  keys,
+  always,
+  compose,
+  pluck,
+  prop,
+  map,
+  identity,
+  path,
+  has,
+  ifElse,
+  isNil,
+  complement,
+  defaultTo,
+} = R;
+
+const notHas = (prop) => complement(has(prop));
+const createPrefix = (bucket, name) => join(bucket, name);
+
+export const HYPER_BUCKET_PREFIX = "hyper-storage-namespaced";
+
+const [META, CREATED_AT, DELETED_AT] = ["meta.json", "createdAt", "deletedAt"];
 
 /**
+ * @typedef {Object} PutObjectArgs
+ * @property {string} bucket
+ * @property {string} object
+ * @property {any} stream
  *
- * @typedef {Object} CreateDocumentArgs
- * @property {string} db
- * @property {string} id
- * @property {object} doc
+ * @typedef {Object} ObjectArgs
+ * @property {string} bucket
+ * @property {string} object
  *
- * @typedef {Object} RetrieveDocumentArgs
- * @property {string} db
- * @property {string} id
+ * @typedef {Object} ListObjectsArgs
+ * @property {string} bucket
+ * @property {string} [prefix]
  *
- * @typedef {Object} QueryDocumentsArgs
- * @property {string} db
- * @property {QueryArgs} query
+ * @typedef {Object} Msg
+ * @property {string} [msg]
  *
- * @typedef {Object} QueryArgs
- * @property {object} selector
- * @property {string[]} fields
- * @property {number} limit
- * @property {object[]} sort
- * @property {string} use_index
+ * @typedef {Object} Buckets
+ * @property {string[]} buckets
  *
- * @typedef {Object} IndexDocumentArgs
- * @property {string} db
- * @property {string} name
- * @property {string[]} fields
+ * @typedef {Object} Objects
+ * @property {string[]} objects
  *
- * @typedef {Object} ListDocumentArgs
- * @property {string} db
- * @property {number} limit
- * @property {string} startkey
- * @property {string} endkey
- * @property {string[]} keys
- *
- * @typedef {Object} BulkDocumentsArgs
- * @property {string} db
- * @property {object[]} docs
- *
- * @typedef {Object} Response
+ * @typedef {Object} ResponseOk
  * @property {boolean} ok
+ *
+ * @typedef {Msg & ResponseOk} ResponseMsg
+ * @typedef {Buckets & ResponseOk} ResponseBuckets
+ * @typedef {Objects & ResponseOk} ResponseObjects
  */
 
-export default function (_env) {
+/**
+ * @param {{ s3: any, factory: any }} aws
+ * @returns
+ */
+export default function (bucketPrefix, aws) {
+  const { s3 } = aws;
+
+  const client = {
+    makeBucket: Async.fromPromise(lib.makeBucket(s3)),
+    listBuckets: Async.fromPromise(lib.listBuckets(s3)),
+    putObject: Async.fromPromise(lib.putObject(s3)),
+    removeObject: Async.fromPromise(lib.removeObject(s3)),
+    removeObjects: Async.fromPromise(lib.removeObjects(s3)),
+    getObject: Async.fromPromise(lib.getObject(s3)),
+    listObjects: Async.fromPromise(lib.listObjects(s3)),
+  };
+
+  // The single bucket used for all objects
+  const namespacedBucket = `${HYPER_BUCKET_PREFIX}-${bucketPrefix}`;
+
   /**
+   * Get the meta.json for the namespaced s3 bucket
+   * which holds information like namespace names and when they were created
+   *
+   * If meta object does not exist, it will be created.
+   * Otherwise, will reject if an unhandled error is received.
+   *
+   * @returns {object}
+   */
+  function getMeta() {
+    return Async.of()
+      .chain(() => client.getObject({ bucket: namespacedBucket, key: META }))
+      /**
+       * Find or create the meta.json object
+       */
+      .bichain(
+        (err) => {
+          return err.message.includes("NoSuchKey")
+            // Create
+            ? Async.of({ [CREATED_AT]: new Date().toISOString() })
+              .chain((meta) =>
+                client.putObject({
+                  bucket: namespacedBucket,
+                  key: META,
+                  body: meta,
+                }).map(() => meta)
+              )
+            : Async.Rejected(err); // Some other error
+        },
+        // Found
+        (r) =>
+          Async.of(r)
+            .map((r) => JSON.parse(new TextDecoder().decode(r.Body))),
+      );
+  }
+
+  /**
+   * Save the meta object in the namespaced bucket
+   * as meta.json
+   */
+  function saveMeta(meta) {
+    return client.putObject({
+      bucket: namespacedBucket,
+      key: META,
+      body: meta,
+    });
+  }
+
+  /**
+   * grab a list of objects at the prefix
+   * remove them
+   * check if list was truncated, and recurse if so
+   * when recursing is done, all object under prefix have been removed
+   */
+  function removeObjects(prefix) {
+    return client.listObjects({
+      bucket: namespacedBucket,
+      prefix,
+    })
+      .chain(
+        (data) =>
+          Async.of(data)
+            // gather the keys
+            .map(
+              compose(
+                pluck("Key"),
+                prop("Contents"),
+              ),
+            )
+            .chain((keys) =>
+              client.removeObjects({ bucket: namespacedBucket, keys })
+            )
+            .chain(() =>
+              // https://doc.deno.land/https://aws-api.deno.dev/v0.3/services/s3.ts?docs=full/~/ListObjectsOutput#IsTruncated
+              data.isTruncated
+                ? removeObjects(prefix) // recurse to delete more objects
+                : Async.Resolved()
+            ),
+      );
+  }
+
+  /**
+   * check the provided meta object for the existence
+   * of the provided namespace
+   *
+   * the namespace may have been deleted, so we check for if the key exists
+   * and if so, if the deletedAt key is set
+   */
+  function checkNamespaceExists(meta, name) {
+    return Async.of(meta)
+      .map(
+        compose(
+          ifElse(
+            isNil,
+            always(false), // no namespace key
+            notHas(DELETED_AT), // set deletedAt means namespace was deleted, so does not exist
+          ),
+          prop(name),
+          defaultTo({}),
+        ),
+      )
+      .chain(ifElse(
+        identity,
+        Async.Resolved, // does exist
+        Async.Rejected, // does not exist
+      ));
+  }
+
+  /**
+   * Create a namespace (prefix/folder) within the s3 bucket
+   * recording it's existence in the meta file
+   *
    * @param {string} name
-   * @returns {Promise<Response>}
+   * @returns {Promise<ResponseMsg>}
    */
-  async function createDatabase(name) {}
+  function makeNamespace(name) {
+    // will succeed if the bucket already exists
+    return client.makeBucket(namespacedBucket)
+      .chain(getMeta)
+      .chain((meta) =>
+        checkNamespaceExists(meta, name)
+          .bichain(
+            /**
+             * Set a key for the new namespace
+             * NOTE: this also removes any deletedAt for the namespace
+             */
+            () =>
+              Async.Resolved(
+                assoc(name, { [CREATED_AT]: new Date().toISOString() }, meta),
+              ),
+            // The namespace already exists
+            () => Async.Rejected("bucket already exists"),
+          )
+      )
+      .chain(saveMeta)
+      .bimap(
+        mapErr,
+        identity,
+      )
+      .bimap(
+        (msg) => ({ ok: false, msg }),
+        always({ ok: true }),
+      ).toPromise();
+  }
 
   /**
+   * Remove a namespace aka. folder/prefix in the bucket
+   * This is done by simply querying for all of the objects with
+   * the prefix and deleting them.
+   *
+   * If the result isTruncated, then we recurse, until all objects with
+   * the prefix are deleted, effectively deleting the namespace.
+   *
+   * Finally, we remove the bucket from the meta file
+   *
    * @param {string} name
-   * @returns {Promise<Response>}
+   * @returns {Promise<ResponseMsg>}
    */
-  async function removeDatabase(name) {}
+  function removeNamespace(name) {
+    return Async.of(name)
+      .chain(checkName)
+      .chain(getMeta)
+      .chain((meta) =>
+        checkNamespaceExists(meta, name)
+          .bichain(
+            () => Async.Rejected("bucket does not exist"),
+            () => removeObjects(name),
+          )
+          .chain(
+            () =>
+              Async.of(
+                assocPath([name, DELETED_AT], new Date().toISOString(), meta),
+              )
+                .chain(saveMeta),
+          )
+      )
+      .bimap(
+        mapErr,
+        identity,
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        always({ ok: true }),
+      ).toPromise();
+  }
 
   /**
-   * @param {CreateDocumentArgs}
-   * @returns {Promise<Response>}
+   * @returns {Promise<ResponseBuckets>}
    */
-  async function createDocument({ db, id, doc }) {}
+  function listNamespaces() {
+    return getMeta()
+      .map(dissoc(CREATED_AT))
+      .map(keys)
+      .bimap(
+        mapErr,
+        identity,
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        (bucketNamesArr) => ({ ok: true, buckets: bucketNamesArr }),
+      ).toPromise();
+  }
 
   /**
-   * @param {RetrieveDocumentArgs}
-   * @returns {Promise<Response>}
+   * @param {PutObjectArgs}
+   * @returns {Promise<ResponseOk>}
    */
-  async function retrieveDocument({ db, id }) {}
+  async function putObject({ bucket, object, stream }) {
+    const arrBuffer = await readAll(stream);
+
+    return Async.of(object)
+      .chain(checkName)
+      .chain(getMeta)
+      .chain(
+        (meta) => checkNamespaceExists(meta, bucket),
+      )
+      .chain(() =>
+        client.putObject({
+          bucket: namespacedBucket,
+          key: createPrefix(bucket, object),
+          body: arrBuffer,
+        })
+      )
+      .bimap(
+        mapErr,
+        identity,
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        always({ ok: true }),
+      ).toPromise();
+  }
 
   /**
-   * @param {CreateDocumentArgs}
-   * @returns {Promise<Response>}
+   * @param {ObjectArgs}
+   * @returns {Promise<ResponseOk>}
    */
-  async function updateDocument({ db, id, doc }) {}
+  function removeObject({ bucket, object }) {
+    return Async.of(object)
+      .chain(checkName)
+      .chain(getMeta)
+      .chain(
+        (meta) => checkNamespaceExists(meta, bucket),
+      )
+      .chain(() =>
+        client.removeObject({
+          bucket: namespacedBucket,
+          key: createPrefix(bucket, object),
+        })
+      )
+      .bimap(
+        mapErr,
+        identity,
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        always({ ok: true }),
+      ).toPromise();
+  }
 
   /**
-   * @param {RetrieveDocumentArgs}
-   * @returns {Promise<Response>}
+   * @param {ObjectArgs}
+   * @returns {Promise<Buffer>}
    */
-  async function removeDocument({ db, id }) {}
+  function getObject({ bucket, object }) {
+    return Async.of(object)
+      .chain(checkName)
+      .chain(getMeta)
+      .chain(
+        (meta) => checkNamespaceExists(meta, bucket),
+      )
+      .chain(() =>
+        client.getObject({
+          bucket: namespacedBucket,
+          key: createPrefix(bucket, object),
+        })
+      )
+      .bimap(
+        mapErr,
+        path(["Body", "buffer"]),
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        (arrayBuffer) => new Buffer(arrayBuffer),
+      ).toPromise();
+  }
 
   /**
-   * @param {QueryDocumentsArgs}
-   * @returns {Promise<Response>}
+   * @param {ListObjectsArgs}
+   * @returns {Promise<ResponseObjects>}
    */
-  async function queryDocuments({ db, query }) {}
-
-  /**
-   *
-   * @param {IndexDocumentArgs}
-   * @returns {Promise<Response>}
-   */
-
-  async function indexDocuments({ db, name, fields }) {}
-
-  /**
-   *
-   * @param {ListDocumentArgs}
-   * @returns {Promise<Response>}
-   */
-  async function listDocuments(
-    { db, limit, startkey, endkey, keys, descending },
-  ) {}
-
-  /**
-   *
-   * @param {BulkDocumentsArgs}
-   * @returns {Promise<Response>}
-   */
-  async function bulkDocuments({ db, docs }) {}
+  function listObjects({ bucket, prefix }) {
+    return Async.of(prefix)
+      .chain(checkName)
+      .chain(getMeta)
+      .chain(
+        (meta) => checkNamespaceExists(meta, bucket),
+      )
+      .chain(() =>
+        client.listObjects({
+          bucket: namespacedBucket,
+          prefix: createPrefix(bucket, prefix),
+        })
+      )
+      .bimap(
+        mapErr,
+        compose(
+          map(prop("Key")),
+          prop("Contents"),
+        ),
+      ).bimap(
+        (msg) => ({ ok: false, msg }),
+        (objectNamesArr) => ({ ok: true, objects: objectNamesArr }),
+      ).toPromise();
+  }
 
   return Object.freeze({
-    createDatabase,
-    removeDatabase,
-    createDocument,
-    retrieveDocument,
-    updateDocument,
-    removeDocument,
-    queryDocuments,
-    indexDocuments,
-    listDocuments,
-    bulkDocuments,
+    makeBucket: makeNamespace,
+    removeBucket: removeNamespace,
+    listBuckets: listNamespaces,
+    putObject,
+    removeObject,
+    getObject,
+    listObjects,
   });
 }

--- a/mod.js
+++ b/mod.js
@@ -21,6 +21,10 @@ export default (
   bucketPrefix,
   { awsAccessKeyId, awsSecretKey, region } = {},
 ) => {
+  if (!bucketPrefix || bucketPrefix.length > 32) {
+    throw new Error("bucketPrefix must a string 1-32 alphanumeric characters");
+  }
+
   const setPrefixOn = (obj) => assoc("prefix", __, obj); // expects object
   const setAwsCreds = (env) =>
     mergeRight(

--- a/test/adapter.test.js
+++ b/test/adapter.test.js
@@ -1,11 +1,434 @@
-import { assert, validateDataAdapterSchema } from "../dev_deps.js";
+import {
+  assert,
+  assertEquals,
+  assertObjectMatch,
+  spy,
+  validateStorageAdapterSchema,
+} from "../dev_deps.js";
 
 import adapterBuilder from "../adapter.js";
+import { Buffer } from "../deps.js";
 
-const adapter = adapterBuilder();
+const resolves = (val) => () => Promise.resolve(val);
+const rejects = (val) => () => Promise.reject(val);
 
-Deno.test("should implement the port", () => {
-  assert(validateDataAdapterSchema(adapter));
+const existingNamespace = "foo";
+// mock client
+const s3 = {
+  getObject: () => {
+    return Promise.resolve({
+      Body: new TextEncoder().encode(
+        JSON.stringify({
+          createdAt: new Date().toISOString(),
+          [existingNamespace]: { createdAt: new Date() },
+        }),
+      ),
+    });
+  },
+};
+
+const adapter = adapterBuilder("foo", { s3 });
+
+const { test } = Deno;
+
+test("should implement the port", () => {
+  assert(validateStorageAdapterSchema(adapter));
 });
 
-// Add more tests here for your adapter logic
+test("makeBucket - make a bucket and namespace and return the correct shape", async () => {
+  s3.createBucket = spy(resolves());
+  s3.putObject = spy(resolves());
+
+  const res = await adapter.makeBucket("no_foo");
+  assert(res.ok);
+});
+
+test("makeBucket - creates the meta document if it doesn't exist", async () => {
+  s3.createBucket = spy(resolves());
+  s3.putObject = spy(resolves());
+
+  const original = s3.getObject;
+  s3.getObject = () => Promise.reject(new Error("NoSuchKey - found"));
+
+  await adapter.makeBucket("no_foo");
+
+  // first call is to create the meta object
+  const { Body } = s3.putObject.calls.shift().args.pop();
+
+  assert(Body.createdAt);
+
+  // cleanup
+  s3.getObject = original;
+});
+
+test("makeBucket - updates the meta document", async () => {
+  s3.createBucket = spy(resolves());
+  s3.putObject = spy(resolves());
+
+  await adapter.makeBucket("new");
+
+  assertObjectMatch(s3.putObject.calls.shift(), {
+    args: [{ Body: { new: { createdAt: new Date().toISOString() } } }],
+  });
+});
+
+test("makeBucket - rejects if failed to create a bucket and return correct shape", async () => {
+  s3.createBucket = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.makeBucket("bar");
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+  }
+});
+
+test("makeBucket - rejects if namespace already exists", async () => {
+  s3.createBucket = spy(resolves());
+  s3.putObject = spy(resolves());
+
+  await adapter.makeBucket(existingNamespace).then(() => {
+    assert(false);
+  }).catch((err) => {
+    assert(!err.ok);
+    assertEquals("bucket already exists", err.msg);
+  });
+});
+
+test("all - fail to get meta object and return correct shape", async () => {
+  s3.createBucket = spy(resolves());
+
+  const original = s3.getObject;
+  s3.getObject = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.makeBucket("bar");
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+    s3.getObject = original;
+  }
+});
+
+test("removeBucket - remove a namespace and return the correct shape", async () => {
+  s3.listObjects = spy(
+    resolves({ Contents: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }] }),
+  );
+  s3.deleteObjects = spy(resolves());
+
+  const res = await adapter.removeBucket(existingNamespace);
+
+  assert(res.ok);
+
+  const { Bucket, Delete } = s3.deleteObjects.calls.shift().args.pop();
+
+  assert(Bucket);
+  assertEquals(Delete, {
+    Objects: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }],
+  });
+});
+
+test("removeBucket - should update the meta, setting deletedAt for the namespace", async () => {
+  s3.listObjects = spy(
+    resolves({ Contents: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }] }),
+  );
+  s3.deleteObjects = spy(resolves());
+  s3.putObject = spy(resolves());
+
+  await adapter.removeBucket(existingNamespace);
+
+  const { Body } = s3.putObject.calls.shift().args.pop();
+
+  assert(Body[existingNamespace].createdAt);
+  assert(Body[existingNamespace].deletedAt);
+});
+
+test("removeBucket - should recursively delete objects", async () => {
+  let called = false;
+  s3.listObjects = spy(
+    () => {
+      // return isTruncated to trigger recursive call
+      if (!called) {
+        called = true;
+        return Promise.resolve({
+          isTruncated: true,
+          Contents: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }],
+        });
+      }
+
+      return Promise.resolve(
+        { Contents: [{ Key: "fizz/buzz.jpg" }, { Key: "fizz/fuzz.png" }] },
+      );
+    },
+  );
+  s3.deleteObjects = spy(resolves());
+
+  const res = await adapter.removeBucket(existingNamespace);
+
+  assert(res.ok);
+
+  assert(s3.deleteObjects.calls.length === 2);
+
+  const { Bucket, Delete } = s3.deleteObjects.calls.shift().args.pop();
+
+  assert(Bucket);
+  assertEquals(Delete, {
+    Objects: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }],
+  });
+
+  const { Bucket: recurseBucket, Delete: recurseDelete } = s3.deleteObjects
+    .calls.shift().args.pop();
+
+  assert(recurseBucket);
+  assertEquals(recurseDelete, {
+    Objects: [{ Key: "fizz/buzz.jpg" }, { Key: "fizz/fuzz.png" }],
+  });
+});
+
+test("removeBucket - remove a namespace and return the correct shape", async () => {
+  s3.listObjects = spy(
+    resolves({ Contents: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }] }),
+  );
+  s3.deleteObjects = spy(resolves());
+
+  const res = await adapter.removeBucket(existingNamespace);
+
+  assert(res.ok);
+
+  const { Bucket, Delete } = s3.deleteObjects.calls.shift().args.pop();
+
+  assert(Bucket);
+  assertEquals(Delete, {
+    Objects: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }],
+  });
+});
+
+test("removeBucket - rejects if namespace doesn't exist", async () => {
+  try {
+    await adapter.removeBucket("no_foo");
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "bucket does not exist");
+  }
+});
+
+test("removeBucket - rejects if failed to remove namespace and return correct shape", async () => {
+  s3.listObjects = spy(
+    resolves({ Contents: [{ Key: "foo" }, { Key: "bar" }] }),
+  );
+  s3.deleteObjects = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.removeBucket(existingNamespace);
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+  }
+});
+
+test("listBuckets - return the correct shape", async () => {
+  const original = s3.getObject;
+  s3.getObject = () =>
+    Promise.resolve({
+      Body: new TextEncoder().encode(
+        JSON.stringify({
+          createdAt: new Date().toISOString(),
+          foo: { createdAt: new Date().toISOString() },
+          bar: { createdAt: new Date().toISOString() },
+        }),
+      ),
+    });
+
+  const res = await adapter.listBuckets();
+
+  assert(res.ok);
+  assertEquals(res.buckets, ["foo", "bar"]);
+
+  s3.getObject = original;
+});
+
+test("listBuckets - fail and return correct shape", async () => {
+  const original = s3.getObject;
+  s3.getObject = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.listBuckets("bar");
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+    s3.getObject = original;
+  }
+});
+
+test("putObject - return the correct shape", async () => {
+  s3.putObject = spy(({ body }) => Promise.resolve(body));
+
+  const res = await adapter.putObject({
+    bucket: existingNamespace,
+    object: "bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  });
+
+  assert(res.ok);
+});
+
+test("all - passes the correct prefix", async () => {
+  s3.putObject = spy(({ body }) => Promise.resolve(body));
+
+  await adapter.putObject({
+    bucket: existingNamespace,
+    object: "/fizz/buzz/bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  });
+
+  // no leading slash
+  await adapter.putObject({
+    bucket: existingNamespace,
+    object: "buzz/bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  });
+
+  assertObjectMatch(s3.putObject.calls.shift(), {
+    args: [{ Key: `${existingNamespace}/fizz/buzz/bar.jpg` }],
+  });
+
+  assertObjectMatch(s3.putObject.calls.shift(), {
+    args: [{ Key: `${existingNamespace}/buzz/bar.jpg` }],
+  });
+});
+
+test("all - reject if name is invalid", async () => {
+  s3.putObject = spy(({ body }) => Promise.resolve(body));
+
+  await adapter.putObject({
+    bucket: existingNamespace,
+    object: "/foo/bar/../bar.jpg",
+    stream: new Buffer(new Uint8Array(4).buffer),
+  })
+    .then(() => assert(false))
+    .catch((err) => {
+      assert(!err.ok);
+      assert(typeof err.msg === "string");
+    });
+});
+
+test("putObject - fail and return correct shape", async () => {
+  s3.putObject = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.putObject({
+      bucket: existingNamespace,
+      object: "bar.jpg",
+      stream: new Buffer(new Uint8Array(4).buffer),
+    });
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+  }
+});
+
+test("removeObject - return the correct shape", async () => {
+  s3.deleteObject = spy(resolves());
+  const res = await adapter.removeObject({
+    bucket: existingNamespace,
+    object: "bar.jpg",
+  });
+
+  assert(res.ok);
+});
+
+test("removeObject - fail and return correct shape", async () => {
+  s3.deleteObject = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.removeObject({
+      bucket: existingNamespace,
+      object: "bar.jpg",
+    });
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+  }
+});
+
+test("getObject - return the correct shape", async () => {
+  const reader = new Buffer(new Uint8Array(4));
+
+  const original = s3.getObject;
+  s3.getObject = ({ Key }) => {
+    if (Key === "meta.json") {
+      return original();
+    }
+
+    return Promise.resolve({ Body: { buffer: reader } });
+  };
+
+  const res = await adapter.getObject({
+    bucket: existingNamespace,
+    object: "bar.jpg",
+  });
+
+  assert(res.read);
+  assertEquals(res.length, reader.length);
+
+  s3.getObject = original;
+});
+
+test("getObject - fail and return correct shape", async () => {
+  const original = s3.getObject;
+  s3.getObject = ({ Key }) => {
+    if (Key === "meta.json") {
+      return original();
+    }
+
+    return Promise.reject(new Error("foo"));
+  };
+
+  try {
+    await adapter.getObject({
+      bucket: existingNamespace,
+      object: "bar.jpg",
+    });
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+    s3.getObject = original;
+  }
+});
+
+test("listObjects - return the correct shape", async () => {
+  s3.listObjects = spy(
+    resolves({ Contents: [{ Key: "foo" }, { Key: "bar" }] }),
+  );
+
+  const res = await adapter.listObjects({
+    bucket: existingNamespace,
+    prefix: "bar",
+  });
+
+  assert(res.ok);
+  assertEquals(res.objects, ["foo", "bar"]);
+});
+
+test("listObjects - fail and return correct shape", async () => {
+  s3.listObjects = spy(rejects(new Error("foo")));
+
+  try {
+    await adapter.listObjects({
+      bucket: "foo",
+      prefix: "bar",
+    });
+    assert(false);
+  } catch (err) {
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "foo");
+  }
+});

--- a/test/adapter.test.js
+++ b/test/adapter.test.js
@@ -112,6 +112,19 @@ test("all - fail to get meta object and return correct shape", async () => {
   }
 });
 
+test("all - namespace is invalid name", async () => {
+  s3.createBucket = spy(resolves());
+
+  try {
+    await adapter.makeBucket("../uhoh/invalid-namespace");
+    assert(false);
+  } catch (err) {
+    console.log(err)
+    assertEquals(err.ok, false);
+    assertEquals(err.msg, "name cannot contain '..'");
+  }
+});
+
 test("removeBucket - remove a namespace and return the correct shape", async () => {
   s3.listObjects = spy(
     resolves({ Contents: [{ Key: "fizz/foo.jpg" }, { Key: "fizz/bar.png" }] }),

--- a/test/mod.test.js
+++ b/test/mod.test.js
@@ -14,6 +14,12 @@ test("should be a valid schema", () => {
   assert(validateFactorySchema(factory));
 });
 
+test("should error if prefix is longer than 32 characters", () => {
+  assertThrows(
+    () => createFactory("aprefixlongerthan32characterswowthisisreallylong"),
+  );
+});
+
 test("should error if prefix is falsey", () => {
   assertThrows(
     () => createFactory(""),


### PR DESCRIPTION
Initial implementation of the s3 namespaced adapter:

- Each hyper Storage service is a folder (prefix) within a single s3 bucket
- a `meta.json` is stored at the root of the bucket that keeps track of when the bucket was created, when each namespace was created, and if and when each namespace was deleted:

`meta.json`:
```js
{
  createdAt: '2022-01-27T16:45:40.152Z',
  foo-namespace: {
    createdAt: '2022-01-27T18:45:40.152Z'
  },
  bar-namespace: {
    createdAt: '2022-01-27T16:45:40.152Z',
    deletedAt: '2022-01-27T19:45:40.152Z'
  }
}
```
This is used to keep track of what namespaces exist

- When a namespace is created or deleted, the name is first checked for in the `meta.json` file
- When an object is created in a namespace (a bucket from a user's perspective), the object is created with the namespace prepended to the objects prefix. ie. object `foo.json` in "bucket" "foo-namespace" becomes object `foo-namespace/foo.json` in the single bucket
- namespaces and object names are checked for `..` to prevent attacks that traverse out of a prefix
- Deleting a namespace (a bucket from the user's perspective) is simply removing all objects with a matching prefix. There is a recursive call here, in case there are more than 1000 objects under the given prefix.